### PR TITLE
@dblock => 1.9.3 build fix, and fixed comment

### DIFF
--- a/lib/artsy/client/api/artwork_inventory.rb
+++ b/lib/artsy/client/api/artwork_inventory.rb
@@ -6,7 +6,7 @@ module Artsy
 
         # Creates an artwork inventory object.
         #
-        # @return [Artsy::Client::Domain::Inventory]
+        # @return [Artsy::Client::Domain::ArtworkInventory]
         def create_artwork_inventory(params = {})
           object_from_response(self, Artsy::Client::Domain::ArtworkInventory, :put, "/api/v1/artwork/#{params[:artwork_id]}/inventory", params)
         end

--- a/lib/artsy/client/api/ordered_set.rb
+++ b/lib/artsy/client/api/ordered_set.rb
@@ -23,7 +23,8 @@ module Artsy
         # @return [Artsy::Client::Domain::OrderedSet]
         def add_to_ordered_set(id, params = {})
           set = ordered_set(id)
-          type_class = Object.const_get "Artsy::Client::Domain::#{set[:item_type]}"
+          # Ruby 1.9.3 cannot handle const_get for nested Classes (Ruby 2.0 can).
+          type_class = "Artsy::Client::Domain::#{set[:item_type]}".split("::").reduce(Object) { |a, e| a.const_get e }
           object_from_response(self, type_class, :post, "/api/v1/set/#{id}/item", params)
         end
       end


### PR DESCRIPTION
Help found here: http://stackoverflow.com/questions/13162607/does-object-const-get-work-with-strings-i-get-a-wrong-constant-name-error

Now tested locally on 1.9.3, 2.0, and 2.1
