### PR TITLE
@dblock Add delayed_task for rebuilding related sales and features of an artwork

### DIFF
--- a/lib/artsy/client/api.rb
+++ b/lib/artsy/client/api.rb
@@ -1,5 +1,6 @@
 require 'artsy/client/api/parse'
 require 'artsy/client/api/system'
+require 'artsy/client/api/delayed_task'
 require 'artsy/client/api/me'
 require 'artsy/client/api/artist'
 require 'artsy/client/api/artwork'

--- a/lib/artsy/client/api/delayed_task.rb
+++ b/lib/artsy/client/api/delayed_task.rb
@@ -1,0 +1,16 @@
+module Artsy
+  module Client
+    module API
+      module DelayedTask
+        include Artsy::Client::API::Parse
+
+        # Rebuild a delayed task.
+        #
+        # @return [Artsy::Client::Domain::DelayedTask]
+        def rebuild_delayed_task(task_id, params = {})
+          object_from_response(self, Artsy::Client::Domain::DelayedTask, :put, "/api/v1/delayed_task/#{task_id}/rebuild", params)
+        end
+      end
+    end
+  end
+end

--- a/lib/artsy/client/domain.rb
+++ b/lib/artsy/client/domain.rb
@@ -1,4 +1,5 @@
 require 'artsy/client/domain/system'
+require 'artsy/client/domain/delayed_task'
 require 'artsy/client/domain/user'
 require 'artsy/client/domain/artist'
 require 'artsy/client/domain/artwork'

--- a/lib/artsy/client/domain/delayed_task.rb
+++ b/lib/artsy/client/domain/delayed_task.rb
@@ -1,0 +1,11 @@
+module Artsy
+  module Client
+    module Domain
+      class DelayedTask < Artsy::Client::Base
+        def id
+          self[:_id]
+        end
+      end
+    end
+  end
+end

--- a/lib/artsy/client/instance.rb
+++ b/lib/artsy/client/instance.rb
@@ -4,6 +4,7 @@ module Artsy
     class Instance
       include Artsy::Client::Configurable
       include Artsy::Client::API::System
+      include Artsy::Client::API::DelayedTask
       include Artsy::Client::API::Me
       include Artsy::Client::API::Artist
       include Artsy::Client::API::Artwork

--- a/spec/fixtures/rebuild_delayed_task.json
+++ b/spec/fixtures/rebuild_delayed_task.json
@@ -1,0 +1,1 @@
+{"status": "success"}

--- a/spec/lib/artsy/client/api/delayed_task_spec.rb
+++ b/spec/lib/artsy/client/api/delayed_task_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Artsy::Client::API::DelayedTask do
+  before do
+    @client = Artsy::Client::Instance.new
+  end
+  describe "#rebuild_delayed_task" do
+    before do
+      stub_put("/api/v1/delayed_task/9/rebuild").to_return(body: fixture("rebuild_delayed_task.json"), headers: { content_type: "application/json; charset=utf-8" })
+    end
+    it "returns success status" do
+      status = @client.rebuild_delayed_task(9)
+      expect(status.status).to eq('success')
+    end
+  end
+end


### PR DESCRIPTION
Support rebuild delayed tasks api endpoint. This will be used on the artwork page to display appropriate bidding form. Thanks!
